### PR TITLE
Ignore Files and Folders from Visualisation

### DIFF
--- a/ignore.json
+++ b/ignore.json
@@ -1,6 +1,3 @@
 {
-  "ignore":[
-    ".git",
-    "vendor"
-  ]
+  "ignore": [".git", "vendor"]
 }

--- a/ignore.json
+++ b/ignore.json
@@ -1,0 +1,6 @@
+{
+  "ignore":[
+    ".git",
+    "vendor"
+  ]
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -16,9 +17,16 @@ func main() {
 	fmt.Println(languageCountArray)
 	writeSummary(languageCountArray)
 	fileStats := getFileStats(".")
+	// Apply ignore list filtering.
+	ignoreList, err := loadIgnoreList()
+	if err != nil {
+		fmt.Println("Error loading ignore list:", err)
+	} else {
+		fileStats = filterIgnoredFiles(fileStats, ignoreList)
+	}
 	svgOutput := generateSVG(fileStats)
 	fmt.Println(svgOutput) // or write to a file
-	err := os.WriteFile("diagram.svg", []byte(svgOutput), 0644)
+	err = os.WriteFile("diagram.svg", []byte(svgOutput), 0644)
 	if err != nil {
 		fmt.Println("Error writing SVG file:", err)
 	}
@@ -69,6 +77,49 @@ func getFileStats(root string) []FileStat {
 		return nil
 	})
 	return stats
+}
+
+// Update loadIgnoreList to parse JSON with an "ignore" key.
+func loadIgnoreList() ([]string, error) {
+	data, err := os.ReadFile("ignore.json")
+	if err != nil {
+		return nil, err
+	}
+	var config struct {
+		Ignore []string `json:"ignore"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+	return config.Ignore, nil
+}
+
+// filterIgnoredFiles filters out FileStat entries whose Path matches any pattern in the ignore list.
+// If a pattern does not include wildcards and matches a folder name, all files under that folder are ignored.
+func filterIgnoredFiles(stats []FileStat, ignoreList []string) []FileStat {
+	var filtered []FileStat
+	for _, stat := range stats {
+		ignore := false
+		for _, pattern := range ignoreList {
+			// First, check if pattern has wildcards.
+			if strings.ContainsAny(pattern, "*?[]") {
+				if matched, _ := filepath.Match(pattern, stat.Path); matched {
+					ignore = true
+					break
+				}
+			} else {
+				// No wildcard: if the file path equals the pattern or starts with pattern + separator, ignore it.
+				if stat.Path == pattern || strings.HasPrefix(stat.Path, pattern+string(os.PathSeparator)) {
+					ignore = true
+					break
+				}
+			}
+		}
+		if !ignore {
+			filtered = append(filtered, stat)
+		}
+	}
+	return filtered
 }
 
 // groupFileStatsByFolder groups file stats by their top-level folder.


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces functionality to filter out files and directories based on an ignore list defined in a JSON file. The changes include adding the necessary JSON parsing, updating the main function to apply the filtering, and implementing the filtering logic.

### Enhancements to file filtering:

* [`ignore.json`](diffhunk://#diff-87361699ebe16f272a1398d6c1cea58e61bcb72410bd775a238ecf731a195020R1-R6): Added a new JSON file to specify files and directories to ignore.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R4): Imported the `encoding/json` package to handle JSON parsing.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R20-R29): Updated the `main` function to load the ignore list and filter the file statistics accordingly.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R82-R124): Added the `loadIgnoreList` function to read and parse the ignore list from `ignore.json`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R82-R124): Implemented the `filterIgnoredFiles` function to exclude files and directories based on the patterns in the ignore list.

Fixes #25
