### PR TITLE
Fix Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - ".github/actions/setup-dependencies"
-      - ".github/actions/local"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file to simplify the configuration by removing unnecessary directories from the `updates` section.

Configuration simplification:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-L8): Removed the directories `.github/actions/setup-dependencies` and `.github/actions/local` from the `updates` section.
