### PR TITLE
Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.2.1
+        uses: astral-sh/setup-uv@v5.2.2
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -74,7 +74,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.8
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -91,12 +91,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.1
+        uses: github/codeql-action/init@v3.28.8
         with:
           languages: actions
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.1
+        uses: github/codeql-action/analyze@v3.28.8
 
   repository-visualiser:
     name: Repository Visualiser


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to ensure the latest versions of dependencies are used. The most important changes involve updating the versions of `setup-uv` and `codeql-action` to their latest releases.

Dependency updates:

* Updated `astral-sh/setup-uv` from version `v5.2.1` to `v5.2.2` to install the latest version of `uv`. (`[.github/workflows/code-checks.ymlL69-R77](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L69-R77)`)
* Updated `github/codeql-action/upload-sarif` from version `v3.28.1` to `v3.28.8` to upload SARIF files. (`[.github/workflows/code-checks.ymlL69-R77](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L69-R77)`)
* Updated `github/codeql-action/init` from version `v3.28.1` to `v3.28.8` to initialize CodeQL. (`[.github/workflows/code-checks.ymlL94-R99](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L94-R99)`)
* Updated `github/codeql-action/analyze` from version `v3.28.1` to `v3.28.8` to perform CodeQL analysis. (`[.github/workflows/code-checks.ymlL94-R99](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L94-R99)`)
