### PR TITLE
Add Go Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,14 @@ updates:
       time: "01:00"
       timezone: "Europe/London"
     target-branch: "main"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    commit-message:
+      prefix: "deps(go-modules)"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the `.github/dependabot.yml` file to add a new package ecosystem for Go modules with a weekly schedule.

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R33-R43): Added configuration for `gomod` package ecosystem, setting the schedule to weekly on Saturdays at 01:00 in the Europe/London timezone.

Fixes #16
