### PR TITLE
Generate Markdown Content

### DIFF
--- a/visualiser/main.go
+++ b/visualiser/main.go
@@ -35,7 +35,7 @@ func main() {
 	markdownContent := generateMarkdownContent(svgOutput)
 
 	// Post PR comment with SVG image.
-	if err := commentOnPR(svgOutput); err != nil {
+	if err := commentOnPR(markdownContent); err != nil {
 		fmt.Println("Error commenting on PR:", err)
 	}
 	writeSummary(languageCountArray)


### PR DESCRIPTION
# Pull Request

## Description

This pull request to `visualiser/main.go` includes changes to enhance the functionality of generating and posting Markdown content with SVG images in GitHub pull request comments. The most important changes include adding a new function to generate Markdown content and modifying the existing function to use this new Markdown content.

Enhancements to Markdown content generation:

* [`visualiser/main.go`](diffhunk://#diff-7ccd8b79b3553c7bd6e5bbcabffa8a3c5192001f95f13f4fbf6a66d17e44ff96R336-R343): Added a new function `generateMarkdownContent` that generates a Markdown string embedding the SVG image as a base64-encoded string.

Modifications to existing functions:

* [`visualiser/main.go`](diffhunk://#diff-7ccd8b79b3553c7bd6e5bbcabffa8a3c5192001f95f13f4fbf6a66d17e44ff96L371-R381): Modified the `commentOnPR` function to accept Markdown content instead of SVG content, and updated the function body to use the new Markdown content.
* [`visualiser/main.go`](diffhunk://#diff-7ccd8b79b3553c7bd6e5bbcabffa8a3c5192001f95f13f4fbf6a66d17e44ff96R35-R36): Added a call to `generateMarkdownContent` in the `main` function to generate the Markdown content from the SVG output.

Fixes #33
