### PR TITLE
Migrate Ignore to GO File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
-COPY visualiser/*.go visualiser/ignore.json ./
+COPY visualiser/*.go ./
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /application
 

--- a/visualiser/ignore.go
+++ b/visualiser/ignore.go
@@ -1,0 +1,27 @@
+package main
+
+// defaultIgnoreList contains a list of default file and folder patterns to ignore.
+var defaultIgnoreList = []string{
+	".git",         // Git folder
+	"node_modules", // Node.js dependencies
+	"vendor",       // Vendor folder for Go dependencies
+	"*.log",        // Log files
+	"*.tmp",        // Temporary files
+	"*.swp",        // Swap files
+	".DS_Store",    // macOS metadata files
+	"*.exe",        // Executable files
+	"*.dll",        // Dynamic-link library files
+	"*.so",         // Shared object files
+	"*.o",          // Object files
+	"*.a",          // Archive files
+	"*.pyc",        // Compiled Python files
+	"*.class",      // Compiled Java files
+	"*.jar",        // Java archive files
+	"*.war",        // Web application archive files
+	"*.zip",        // Zip archives
+	"*.tar.gz",     // Tarball archives
+	"*.7z",         // 7-Zip archives
+	"*.bak",        // Backup files
+	"*.old",        // Old files
+	"*.orig",       // Original files
+}

--- a/visualiser/ignore.json
+++ b/visualiser/ignore.json
@@ -1,3 +1,0 @@
-{
-  "ignore": [".git", "vendor"]
-}

--- a/visualiser/main.go
+++ b/visualiser/main.go
@@ -28,12 +28,7 @@ func main() {
 		return
 	}
 	// Apply ignore list filtering.
-	ignoreList, err := loadIgnoreList()
-	if err != nil {
-		fmt.Println("Error loading ignore list:", err)
-	} else {
-		fileStats = filterIgnoredFiles(fileStats, ignoreList)
-	}
+	fileStats = filterIgnoredFiles(fileStats, defaultIgnoreList)
 	svgOutput := generateSVG(fileStats)
 
 	markdownContent := generateMarkdownContent(svgOutput)
@@ -83,21 +78,6 @@ func getFileStats(root string) []FileStat {
 		return nil
 	})
 	return stats
-}
-
-// Update loadIgnoreList to parse JSON with an "ignore" key.
-func loadIgnoreList() ([]string, error) {
-	data, err := os.ReadFile("./ignore.json")
-	if err != nil {
-		return nil, err
-	}
-	var config struct {
-		Ignore []string `json:"ignore"`
-	}
-	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, err
-	}
-	return config.Ignore, nil
 }
 
 // filterIgnoredFiles filters out FileStat entries whose Path matches any pattern in the ignore list.


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to simplify the handling of ignored files in the `visualiser` package by replacing a dynamic ignore list loaded from a JSON file with a static default ignore list defined in the code. The most important changes include the addition of a default ignore list, the removal of the JSON-based ignore list loading, and the update to use the default ignore list in the main processing function.

Changes to ignore list handling:

* [`visualiser/ignore.go`](diffhunk://#diff-86dc458e369a0cad377b45954e0baa89a69be194d8002fdc95cb24719d0f7d71R1-R27): Added a `defaultIgnoreList` variable containing patterns for files and folders to ignore.
* [`visualiser/ignore.json`](diffhunk://#diff-fd76827a2c36936f7941e4d7a37fbe3b0201b68b6a3ce9c63b98a32f4c759cacL1-L3): Removed the JSON file that previously contained ignore patterns.
* [`visualiser/main.go`](diffhunk://#diff-7ccd8b79b3553c7bd6e5bbcabffa8a3c5192001f95f13f4fbf6a66d17e44ff96L31-R31): Updated the `main` function to use the `defaultIgnoreList` instead of loading the ignore list from a JSON file.
* [`visualiser/main.go`](diffhunk://#diff-7ccd8b79b3553c7bd6e5bbcabffa8a3c5192001f95f13f4fbf6a66d17e44ff96L88-L102): Removed the `loadIgnoreList` function, which was responsible for loading the ignore list from the JSON file.

Fixes #84
