### PR TITLE
Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-    commit-message:
-      prefix: "deps(github-actions)"
     schedule:
       interval: "daily"
       time: "01:00"
@@ -21,8 +19,6 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    commit-message:
-      prefix: "deps(dockerfile)"
     schedule:
       interval: "daily"
       time: "01:00"
@@ -31,8 +27,6 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/"
-    commit-message:
-      prefix: "deps(go-modules)"
     schedule:
       interval: "daily"
       time: "01:00"


### PR DESCRIPTION
# Pull Request

## Description


This pull request includes changes to the `.github/dependabot.yml` file to simplify the configuration by removing the `commit-message` prefixes for different package ecosystems.

Simplification of `dependabot.yml` configuration:

* Removed `commit-message` prefix for `github-actions` updates.
* Removed `commit-message` prefix for `docker` updates.
* Removed `commit-message` prefix for `gomod` updates.
