### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.15
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -127,13 +127,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.13
+        uses: github/codeql-action/init@v3.28.15
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.13
+        uses: github/codeql-action/analyze@v3.28.15
 
   repository-visualiser:
     name: Repository Visualiser


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL workflow configuration to use the latest versions of the CodeQL actions and removes a custom query filter configuration. The changes aim to streamline the workflow and ensure compatibility with the latest CodeQL features.

### CodeQL Workflow Updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L109-R109): Updated the versions of the `upload-sarif`, `init`, and `analyze` CodeQL actions to `v3.28.15` to ensure the workflow uses the latest features and fixes. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L109-R109) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L130-R135)

### Configuration Simplification:

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the custom query filter for `actions/unpinned-tag`, as it is no longer required.