### PR TITLE
Potential fix for code scanning alert no. 13: Writable file handle closed without error handling

### DIFF
--- a/visualiser/main.go
+++ b/visualiser/main.go
@@ -355,7 +355,11 @@ func writeSummary(languageCountArray LanguageCountArray, markdownContent string)
 			fmt.Println("Error:", err)
 			return
 		}
-		defer file.Close()
+		defer func() {
+			if err := file.Close(); err != nil {
+				fmt.Println("Error closing file:", err)
+			}
+		}()
 
 		var sb strings.Builder
 		sb.WriteString(fmt.Sprintf("%s\n", markdownContent))


### PR DESCRIPTION
Potential fix for [https://github.com/JackPlowman/repository-visualiser/security/code-scanning/13](https://github.com/JackPlowman/repository-visualiser/security/code-scanning/13)

To fix the issue, we need to explicitly handle errors returned by `file.Close()`. This can be achieved by using a `defer` statement with an anonymous function that checks and handles the error. The anonymous function will ensure that any error from `file.Close()` is logged or propagated appropriately. Additionally, we should ensure that the error from `file.Close()` does not overwrite any prior errors (e.g., from writing to the file).

The changes will be made in the `writeSummary` function, specifically around the `defer file.Close()` statement on line 358.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
