### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
     directories:
       - "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -20,15 +19,13 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       - "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -20,12 +20,12 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration in `.github/dependabot.yml` to use a cron-based schedule instead of the previous daily interval. The changes ensure more precise control over when updates are checked.

**Changes to Dependabot scheduling:**

* Updated the schedule for all package ecosystems (`github-actions`, `docker`, and `gomod`) to use a cron job (`30 7 * * *`) instead of the daily interval with a specific time and timezone. This change provides more flexibility and consistency in scheduling updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R9) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L23-R30)