### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,19 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -21,6 +24,7 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
 
   - package-ecosystem: "gomod"
@@ -28,4 +32,13 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
+    groups:
+      go-modules:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration file to enhance the dependency update process by adding timezone specifications, consolidating directory paths, and introducing grouping rules for updates. These changes improve clarity, organization, and scheduling precision.

### Enhancements to Dependabot configuration:

* Consolidated the `directory` field for `github-actions` updates by replacing the array with a single string value (`"/"`) for simplicity. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Added a `timezone` field (`Europe/London`) to the schedule for both `github-actions` and `gomod` updates to ensure the cron job runs at the correct local time. (`[[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`, `[[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R27-R44)`)

### Introduction of grouping rules:

* For `github-actions` updates, added a `groups` section with the `applies-to` field set to `version-updates`, a `patterns` field to match all updates, and an `exclude-patterns` field to exclude updates for `super-linter/*`. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Introduced a new `groups` section for `gomod` updates, specifying `applies-to` as `version-updates`, a `patterns` field to match all updates, and limiting updates to `patch` and `minor` types. (`[.github/dependabot.ymlR27-R44](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R27-R44)`)