### PR TITLE
Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -44,28 +44,18 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
-  run-codeql-analysis:
+
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [go, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
+        language: [actions, go]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   repository-visualiser:
     name: Repository Visualiser


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to use a reusable workflow, simplifying configuration and improving maintainability.

### Workflow updates:
* Renamed the job from `run-codeql-analysis` to `codeql-checks` for clarity.
* Replaced inline CodeQL steps with a reusable workflow from `JackPlowman/reusable-workflows` (`codeql-analysis.yml`), reducing redundancy and aligning with best practices.
* Adjusted permissions for the job, changing `statuses: write` to `contents: read` for more granular access control.
* Updated the language matrix to `[actions, go]`, maintaining support for the same languages but reordering them for consistency.