### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the documentation file labeling configuration. The change corrects the spelling of the license file in the markdown labeler pattern.

* Changed the file pattern from `LICENSE` to `LICENCE` in the markdown labeler configuration in `.github/other-configurations/labeller.yml`.